### PR TITLE
fix bug: only free atom can be picked up

### DIFF
--- a/pages/delivery.tsx
+++ b/pages/delivery.tsx
@@ -4,23 +4,18 @@ import UnitState, {BgStatus, BorderStatus, UnitText} from '../src/types/UnitStat
 
 export default function Delivery({ delivered }) {
 
-    // const delivered: AtomType[] = props.delivered
-    // console.log('delivered:', delivered)
     if (!delivered || delivered.length == 0) {
         return <></>
     }
 
     let counts: { [key: string] : number } = {}
     for (let typ in AtomType){
-        console.log('visiting', typ as string)
         const count = delivered.filter(t => t == typ).length;
         if (count == 0) {
-            console.log('counted 0 for', typ)
             continue;
         }
         counts[typ as string] = count
     }
-    console.log('counts:', JSON.stringify(counts))
 
     return (
         <>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -18,7 +18,7 @@ export default function Home() {
 
     // Constants
     const N_CYCLES = 100
-    const ANIM_FRAME_LATENCY = 300
+    const ANIM_FRAME_LATENCY = 500
     const INIT_PROGRAM = 'Z,S,S,D,D,X,W,W,A,A'
     const DIM = 8
     const MECH_INIT_X = 0
@@ -311,9 +311,10 @@ export default function Home() {
                 ) as Frame[]
                 setFrames (simulatedFrames)
 
-                simulatedFrames.forEach((f:Frame,i:number) => {
-                    const s = f.mechs.map(function(v){return JSON.stringify(v)}).join('\n')
-                    console.log(i, s)
+                simulatedFrames.forEach((f:Frame,frame_i:number) => {
+                    // const s = f.atoms.map(function(v){return JSON.stringify(v)}).join('\n')
+                    console.log(frame_i, f.atoms)
+                    // console.log(frame_i, f.notes)
                 })
                 const final_delivery = simulatedFrames[simulatedFrames.length-1].delivered_accumulated
                 // var n_vanilla = 0

--- a/pages/simulator.tsx
+++ b/pages/simulator.tsx
@@ -44,7 +44,8 @@ export default function simulator(
         mechs: mechs,
         atoms: atoms,
         grid_populated_bools: grid_populated_bools,
-        delivered_accumulated: []
+        delivered_accumulated: [],
+        notes: ''
     }
 
     //
@@ -100,6 +101,7 @@ function _simulate_one_cycle (
     var mechs_new: MechState[] = []
     var atoms_new: AtomState[] = JSON.parse(JSON.stringify(atoms_curr)) // object cloning
     var grid_populated_bools_new: { [key: string] : boolean } = JSON.parse(JSON.stringify(grid_populated_bools)) // object cloning
+    var notes = ''
 
     //
     // Iterate through atom faucets
@@ -191,7 +193,7 @@ function _simulate_one_cycle (
                 grid_populated_bools_new[JSON.stringify(mech.index)] = false
 
                 atoms_new.forEach(function (atom: AtomState, i: number, theArray: AtomState[]) {
-                    if ( isIdenticalGrid(atom.index, mech.index) ){
+                    if ( isIdenticalGrid(atom.index, mech.index) && atom.status==AtomStatus.FREE ){
                         var atom_new = theArray[i]
                         atom_new.status = AtomStatus.POSSESSED
                         atom_new.possessed_by = mech.id
@@ -250,6 +252,7 @@ function _simulate_one_cycle (
 
             // check for formula match
             if (atom_type_a == AtomType.VANILLA && atom_type_b == AtomType.VANILLA){
+                notes += 'adding vanilla + vanilla'
                 // consume two vanilla atoms to produce one hazelnut atom
                 grid_populated_bools_new[JSON.stringify(binary_operator.a)] = false
                 grid_populated_bools_new[JSON.stringify(binary_operator.b)] = false
@@ -296,7 +299,8 @@ function _simulate_one_cycle (
         mechs: mechs_new,
         atoms: atoms_new,
         grid_populated_bools: grid_populated_bools_new,
-        delivered_accumulated: delivered_accumulated_new
+        delivered_accumulated: delivered_accumulated_new,
+        notes: notes
     }
     return frame_new
 }

--- a/src/types/Frame.ts
+++ b/src/types/Frame.ts
@@ -6,4 +6,5 @@ export default interface Frame {
     atoms: AtomState[]
     grid_populated_bools: { [key: string] : boolean }
     delivered_accumulated: AtomType[]
+    notes: string
 }


### PR DESCRIPTION
the bug was that `Z` operation doesn't check for atom's status, causing "consumed" atom to be picked up.