### PR TITLE
Save solution stores initial mech state

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -695,7 +695,7 @@ export default function Home() {
 
     function handleSaveClick () {
         const solution: Solution = {
-            mechs: mechStates,
+            mechs: mechInitStates,
             programs: programs,
             operators: operatorStates
         }


### PR DESCRIPTION
When saving solution in the middle of a simulation, the _current_ positions of the mechs are saved instead of the _original_. This pr fixes this by storing the initial mech state